### PR TITLE
fix: resolve missing AlertComponent styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
 # vanilla-todo.bytim.dev
 
 Demo todo app created with vanilla TypeScript.
+
+## Things I learned along the way
+
+### Using web components with Vite
+
+When running a build, Vite wants to take all of the imported CSS, code split it, and combine it into a single CSS 
+asset.
+
+This poses a problem with web components:
+
+- If you attempt to include styles by appending a `<link>` element to the component's shadow root, that linked .css 
+file will not resolve.
+- If you attempt to include styles by adding a `<style>` element, Vite will extract it and inline the styles. This 
+will prevent the `<style>` from being attached to the shadow root.
+
+Without the styles being attached to the shadow root, you'll end up with unstyled components.
+
+To prevent this, I ended up doing the following:
+
+1. In the component's .ts file, include the raw contents as a string:
+
+```ts
+import css from "./alert.component.css?raw"
+```
+
+2. Create a `<style>` element and set that variable as its `innerHTML`:
+
+```ts
+const styles = document.createElement("style");
+styles.innerHTML = css;
+this.shadowRoot.appendChild(styles);
+```
+
+3. In tsconfig.json, add ".css" to the `excludes` array so it doesn't trigger "unknown module" errors.
+
+```json
+{
+  "exclude": ["*.css"]
+}
+```

--- a/index.html
+++ b/index.html
@@ -8,13 +8,6 @@
     <meta name="description" content="A demo todo app built using vanilla TypeScript">
     <title>Todo App</title>
     <script type="module" src="./src/main.ts"></script>
-    <script type="module">
-      import { bootstrap } from "./src/main";
-
-      window.addEventListener("load", () => {
-        bootstrap();
-      });
-    </script>
   </head>
   <body>
     <header>

--- a/src/lib/alert.component.ts
+++ b/src/lib/alert.component.ts
@@ -1,4 +1,5 @@
 import feather from "feather-icons";
+import css from "./alert.component.css?raw"
 
 export class AlertComponent extends HTMLElement {
   private readonly type: AlertType;
@@ -27,9 +28,8 @@ export class AlertComponent extends HTMLElement {
       return;
     }
 
-    const styles = document.createElement("link");
-    styles.rel = "stylesheet";
-    styles.href = "./src/lib/alert.component.css";
+    const styles = document.createElement("style");
+    styles.innerHTML = css;
     this.shadowRoot.appendChild(styles);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,11 @@ import { AlertComponent } from "./lib/alert.component";
 import { DisclaimerService } from "./lib/disclaimer.service";
 import "./style.css";
 
-export function bootstrap(): void {
+function bootstrap(): void {
   customElements.define("app-alert", AlertComponent);
   DisclaimerService.showDisclaimer();
 }
+
+window.addEventListener("load", () => {
+  bootstrap();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["*.css"]
 }


### PR DESCRIPTION
- refactor: move bootstrap call to main.ts
- chore: add .css files to tsconfig excludes list
- fix: set AlertComponent styles using `<style>` element
- docs: note how to append styles to web components w/ Vite
